### PR TITLE
Record update expression

### DIFF
--- a/src/NameVisitor.elm
+++ b/src/NameVisitor.elm
@@ -368,10 +368,10 @@ visitRecordField node =
 
 
 visitExpression : Node Expression -> List Name
-visitExpression node =
-    case Node.value node of
+visitExpression (Node range expression) =
+    case expression of
         Expression.FunctionOrValue moduleName function ->
-            visitValue (Node (Node.range node) ( moduleName, function ))
+            visitValue (Node range ( moduleName, function ))
 
         Expression.LetExpression { declarations } ->
             visitLetDeclarationList declarations
@@ -381,6 +381,9 @@ visitExpression node =
 
         Expression.LambdaExpression { args } ->
             visitPatternList args
+
+        Expression.RecordUpdateExpression name _ ->
+            visitValue (Node.map (\function -> ( [], function )) name)
 
         _ ->
             []

--- a/tests/Tests/NameVisitor.elm
+++ b/tests/Tests/NameVisitor.elm
@@ -1,4 +1,4 @@
-module NameVisitorTests exposing (all)
+module Tests.NameVisitor exposing (all)
 
 import Elm.Syntax.ModuleName exposing (ModuleName)
 import Elm.Syntax.Node as Node exposing (Node)

--- a/tests/Tests/NameVisitor.elm
+++ b/tests/Tests/NameVisitor.elm
@@ -162,6 +162,18 @@ view nodes =
                     , expectedValueError context "name"
                         |> Review.Test.atExactly { start = { row = 4, column = 54 }, end = { row = 4, column = 58 } }
                     ]
+    , fuzz Fuzz.string "RecordAccess" <|
+        \context ->
+            """
+module Page exposing (view)
+value model =
+    model.value
+"""
+                |> Review.Test.run (valueOrTypeVisitorRule context)
+                |> Review.Test.expectErrors
+                    [ expectedValueError context "model"
+                        |> Review.Test.atExactly { start = { row = 4, column = 5 }, end = { row = 4, column = 10 } }
+                    ]
     , fuzz Fuzz.string "RecordUpdateExpression" <|
         \context ->
             """

--- a/tests/Tests/NameVisitor.elm
+++ b/tests/Tests/NameVisitor.elm
@@ -12,94 +12,92 @@ import Test exposing (Test, describe, fuzz, test)
 all : Test
 all =
     describe "NameVisitor"
-        [ contextTests
-        , declarationTests
-        , expressionTests
-        , patternTests
-        , typeAnnotationTests
-        , visitorTests
+        [ describe "Context" contextTests
+        , describe "Declarations" declarationTests
+        , describe "Expressions" expressionTests
+        , describe "Patterns" patternTests
+        , describe "Type Annotations" typeAnnotationTests
+        , describe "Visitors" visitorTests
         ]
 
 
-declarationTests : Test
+declarationTests : List Test
 declarationTests =
-    describe "Declaration"
-        [ fuzz Fuzz.string "FunctionDeclaration" <|
-            \context ->
-                """
+    [ fuzz Fuzz.string "FunctionDeclaration" <|
+        \context ->
+            """
 module Page exposing (view)
 view : Node (Html.Attribute msg) -> Html msg
 view (Node attribute) = Html.div [ attribute ] []
 """
-                    |> Review.Test.run (valueOrTypeVisitorRule context)
-                    |> Review.Test.expectErrors
-                        [ expectedTypeError context "Node"
-                            |> Review.Test.atExactly { start = { row = 3, column = 8 }, end = { row = 3, column = 12 } }
-                        , expectedTypeError context "Html.Attribute"
-                        , expectedTypeError context "Html"
-                            |> Review.Test.atExactly { start = { row = 3, column = 37 }, end = { row = 3, column = 41 } }
-                        , expectedValueError context "Node"
-                            |> Review.Test.atExactly { start = { row = 4, column = 7 }, end = { row = 4, column = 11 } }
-                        , expectedValueError context "Html.div"
-                        , expectedValueError context "attribute"
-                            |> Review.Test.atExactly { start = { row = 4, column = 36 }, end = { row = 4, column = 45 } }
-                        ]
-        , fuzz Fuzz.string "AliasDeclaration" <|
-            \context ->
-                """
+                |> Review.Test.run (valueOrTypeVisitorRule context)
+                |> Review.Test.expectErrors
+                    [ expectedTypeError context "Node"
+                        |> Review.Test.atExactly { start = { row = 3, column = 8 }, end = { row = 3, column = 12 } }
+                    , expectedTypeError context "Html.Attribute"
+                    , expectedTypeError context "Html"
+                        |> Review.Test.atExactly { start = { row = 3, column = 37 }, end = { row = 3, column = 41 } }
+                    , expectedValueError context "Node"
+                        |> Review.Test.atExactly { start = { row = 4, column = 7 }, end = { row = 4, column = 11 } }
+                    , expectedValueError context "Html.div"
+                    , expectedValueError context "attribute"
+                        |> Review.Test.atExactly { start = { row = 4, column = 36 }, end = { row = 4, column = 45 } }
+                    ]
+    , fuzz Fuzz.string "AliasDeclaration" <|
+        \context ->
+            """
 module Page exposing (Page)
 type alias Page =
     { title : String
     , body : List (Html msg)
     }
 """
-                    |> Review.Test.run (valueOrTypeVisitorRule context)
-                    |> Review.Test.expectErrors
-                        [ expectedTypeError context "String"
-                        , expectedTypeError context "List"
-                        , expectedTypeError context "Html"
-                        ]
-        , fuzz Fuzz.string "CustomTypeDeclaration" <|
-            \context ->
-                """
+                |> Review.Test.run (valueOrTypeVisitorRule context)
+                |> Review.Test.expectErrors
+                    [ expectedTypeError context "String"
+                    , expectedTypeError context "List"
+                    , expectedTypeError context "Html"
+                    ]
+    , fuzz Fuzz.string "CustomTypeDeclaration" <|
+        \context ->
+            """
 module Page exposing (Page)
 type Page
     = Home Route.Home
 """
-                    |> Review.Test.run (valueOrTypeVisitorRule context)
-                    |> Review.Test.expectErrors
-                        [ expectedTypeError context "Route.Home"
-                        ]
-        , fuzz Fuzz.string "PortDeclaration" <|
-            \context ->
-                """
+                |> Review.Test.run (valueOrTypeVisitorRule context)
+                |> Review.Test.expectErrors
+                    [ expectedTypeError context "Route.Home"
+                    ]
+    , fuzz Fuzz.string "PortDeclaration" <|
+        \context ->
+            """
 port module Ports exposing (alarm)
 port alarm : Json.Encode.Value -> Cmd msg
 """
-                    |> Review.Test.run (valueOrTypeVisitorRule context)
-                    |> Review.Test.expectErrors
-                        [ expectedTypeError context "Json.Encode.Value"
-                        , expectedTypeError context "Cmd"
-                        ]
-        ]
+                |> Review.Test.run (valueOrTypeVisitorRule context)
+                |> Review.Test.expectErrors
+                    [ expectedTypeError context "Json.Encode.Value"
+                    , expectedTypeError context "Cmd"
+                    ]
+    ]
 
 
-expressionTests : Test
+expressionTests : List Test
 expressionTests =
-    describe "Expression"
-        [ fuzz Fuzz.string "FunctionOrValue" <|
-            \context ->
-                """
+    [ fuzz Fuzz.string "FunctionOrValue" <|
+        \context ->
+            """
 module Page exposing (view)
 view = Html.div [] []
 """
-                    |> Review.Test.run (valueOrTypeVisitorRule context)
-                    |> Review.Test.expectErrors
-                        [ expectedValueError context "Html.div"
-                        ]
-        , fuzz Fuzz.string "LetDestructuring" <|
-            \context ->
-                """
+                |> Review.Test.run (valueOrTypeVisitorRule context)
+                |> Review.Test.expectErrors
+                    [ expectedValueError context "Html.div"
+                    ]
+    , fuzz Fuzz.string "LetDestructuring" <|
+        \context ->
+            """
 module Page exposing (view)
 view =
     let
@@ -107,15 +105,15 @@ view =
     in
     html
 """
-                    |> Review.Test.run (valueOrTypeVisitorRule context)
-                    |> Review.Test.expectErrors
-                        [ expectedValueError context "Html.span"
-                        , expectedValueError context "html"
-                            |> Review.Test.atExactly { start = { row = 7, column = 5 }, end = { row = 7, column = 9 } }
-                        ]
-        , fuzz Fuzz.string "LetFunction" <|
-            \context ->
-                """
+                |> Review.Test.run (valueOrTypeVisitorRule context)
+                |> Review.Test.expectErrors
+                    [ expectedValueError context "Html.span"
+                    , expectedValueError context "html"
+                        |> Review.Test.atExactly { start = { row = 7, column = 5 }, end = { row = 7, column = 9 } }
+                    ]
+    , fuzz Fuzz.string "LetFunction" <|
+        \context ->
+            """
 module Page exposing (view)
 view =
     let
@@ -124,315 +122,311 @@ view =
     in
     html
 """
-                    |> Review.Test.run (valueOrTypeVisitorRule context)
-                    |> Review.Test.expectErrors
-                        [ expectedTypeError context "Nested.Html"
-                        , expectedValueError context "Nested.Node"
-                        , expectedValueError context "span"
-                        , expectedValueError context "html"
-                            |> Review.Test.atExactly { start = { row = 8, column = 5 }, end = { row = 8, column = 9 } }
-                        ]
-        , fuzz Fuzz.string "CaseExpression" <|
-            \context ->
-                """
+                |> Review.Test.run (valueOrTypeVisitorRule context)
+                |> Review.Test.expectErrors
+                    [ expectedTypeError context "Nested.Html"
+                    , expectedValueError context "Nested.Node"
+                    , expectedValueError context "span"
+                    , expectedValueError context "html"
+                        |> Review.Test.atExactly { start = { row = 8, column = 5 }, end = { row = 8, column = 9 } }
+                    ]
+    , fuzz Fuzz.string "CaseExpression" <|
+        \context ->
+            """
 module Rule exposing (visitor)
 visitor node =
     case Node.value node of
         Expression.FunctionOrValue _ _ ->
             []
 """
-                    |> Review.Test.run (valueOrTypeVisitorRule context)
-                    |> Review.Test.expectErrors
-                        [ expectedValueError context "Node.value"
-                        , expectedValueError context "node"
-                            |> Review.Test.atExactly { start = { row = 4, column = 21 }, end = { row = 4, column = 25 } }
-                        , expectedValueError context "Expression.FunctionOrValue"
-                        ]
-        , fuzz Fuzz.string "LambdaExpression" <|
-            \context ->
-                """
+                |> Review.Test.run (valueOrTypeVisitorRule context)
+                |> Review.Test.expectErrors
+                    [ expectedValueError context "Node.value"
+                    , expectedValueError context "node"
+                        |> Review.Test.atExactly { start = { row = 4, column = 21 }, end = { row = 4, column = 25 } }
+                    , expectedValueError context "Expression.FunctionOrValue"
+                    ]
+    , fuzz Fuzz.string "LambdaExpression" <|
+        \context ->
+            """
 module Page exposing (view)
 view nodes =
     Html.div [] (List.map (\\(Node name) -> Html.text name))
 """
-                    |> Review.Test.run (valueOrTypeVisitorRule context)
-                    |> Review.Test.expectErrors
-                        [ expectedValueError context "Html.div"
-                        , expectedValueError context "List.map"
-                        , expectedValueError context "Node"
-                        , expectedValueError context "Html.text"
-                        , expectedValueError context "name"
-                            |> Review.Test.atExactly { start = { row = 4, column = 54 }, end = { row = 4, column = 58 } }
-                        ]
-        ]
+                |> Review.Test.run (valueOrTypeVisitorRule context)
+                |> Review.Test.expectErrors
+                    [ expectedValueError context "Html.div"
+                    , expectedValueError context "List.map"
+                    , expectedValueError context "Node"
+                    , expectedValueError context "Html.text"
+                    , expectedValueError context "name"
+                        |> Review.Test.atExactly { start = { row = 4, column = 54 }, end = { row = 4, column = 58 } }
+                    ]
+    ]
 
 
-patternTests : Test
+patternTests : List Test
 patternTests =
-    describe "Pattern"
-        [ fuzz Fuzz.string "TuplePattern" <|
-            \context ->
-                """
+    [ fuzz Fuzz.string "TuplePattern" <|
+        \context ->
+            """
 module Page exposing (view)
 view ( Nested.Node name, Nested.Value value ) =
     Html.div [] [ Html.text (name ++ value) ]
 """
-                    |> Review.Test.run (valueVisitorRule context)
-                    |> Review.Test.expectErrors
-                        [ expectedValueError context "Nested.Node"
-                        , expectedValueError context "Nested.Value"
-                        , expectedValueError context "Html.div"
-                        , expectedValueError context "Html.text"
-                        , expectedValueError context "name"
-                            |> Review.Test.atExactly { start = { row = 4, column = 30 }, end = { row = 4, column = 34 } }
-                        , expectedValueError context "value"
-                            |> Review.Test.atExactly { start = { row = 4, column = 38 }, end = { row = 4, column = 43 } }
-                        ]
-        , fuzz Fuzz.string "UnConsPattern" <|
-            \context ->
-                """
+                |> Review.Test.run (valueVisitorRule context)
+                |> Review.Test.expectErrors
+                    [ expectedValueError context "Nested.Node"
+                    , expectedValueError context "Nested.Value"
+                    , expectedValueError context "Html.div"
+                    , expectedValueError context "Html.text"
+                    , expectedValueError context "name"
+                        |> Review.Test.atExactly { start = { row = 4, column = 30 }, end = { row = 4, column = 34 } }
+                    , expectedValueError context "value"
+                        |> Review.Test.atExactly { start = { row = 4, column = 38 }, end = { row = 4, column = 43 } }
+                    ]
+    , fuzz Fuzz.string "UnConsPattern" <|
+        \context ->
+            """
 module Page exposing (list)
 list children =
     case children of
         (Page.First first) :: (Page.Second second) :: _ ->
             Html.text ""
 """
-                    |> Review.Test.run (valueVisitorRule context)
-                    |> Review.Test.expectErrors
-                        [ expectedValueError context "children"
-                            |> Review.Test.atExactly { start = { row = 4, column = 10 }, end = { row = 4, column = 18 } }
-                        , expectedValueError context "Page.First"
-                        , expectedValueError context "Page.Second"
-                        , expectedValueError context "Html.text"
-                        ]
-        , fuzz Fuzz.string "ListPattern" <|
-            \context ->
-                """
+                |> Review.Test.run (valueVisitorRule context)
+                |> Review.Test.expectErrors
+                    [ expectedValueError context "children"
+                        |> Review.Test.atExactly { start = { row = 4, column = 10 }, end = { row = 4, column = 18 } }
+                    , expectedValueError context "Page.First"
+                    , expectedValueError context "Page.Second"
+                    , expectedValueError context "Html.text"
+                    ]
+    , fuzz Fuzz.string "ListPattern" <|
+        \context ->
+            """
 module Page exposing (list)
 list children =
     case children of
         [ Page.First first, Page.Second second ] ->
             Html.text ""
 """
-                    |> Review.Test.run (valueVisitorRule context)
-                    |> Review.Test.expectErrors
-                        [ expectedValueError context "children"
-                            |> Review.Test.atExactly { start = { row = 4, column = 10 }, end = { row = 4, column = 18 } }
-                        , expectedValueError context "Page.First"
-                        , expectedValueError context "Page.Second"
-                        , expectedValueError context "Html.text"
-                        ]
-        , fuzz Fuzz.string "NamedPattern" <|
-            \context ->
-                """
+                |> Review.Test.run (valueVisitorRule context)
+                |> Review.Test.expectErrors
+                    [ expectedValueError context "children"
+                        |> Review.Test.atExactly { start = { row = 4, column = 10 }, end = { row = 4, column = 18 } }
+                    , expectedValueError context "Page.First"
+                    , expectedValueError context "Page.Second"
+                    , expectedValueError context "Html.text"
+                    ]
+    , fuzz Fuzz.string "NamedPattern" <|
+        \context ->
+            """
 module Page exposing (view)
 view (Node name) = Html.text name
 """
-                    |> Review.Test.run (valueVisitorRule context)
-                    |> Review.Test.expectErrors
-                        [ expectedValueError context "Node"
-                        , expectedValueError context "Html.text"
-                        , expectedValueError context "name"
-                            |> Review.Test.atExactly { start = { row = 3, column = 30 }, end = { row = 3, column = 34 } }
-                        ]
-        , fuzz Fuzz.string "AsPattern" <|
-            \context ->
-                """
+                |> Review.Test.run (valueVisitorRule context)
+                |> Review.Test.expectErrors
+                    [ expectedValueError context "Node"
+                    , expectedValueError context "Html.text"
+                    , expectedValueError context "name"
+                        |> Review.Test.atExactly { start = { row = 3, column = 30 }, end = { row = 3, column = 34 } }
+                    ]
+    , fuzz Fuzz.string "AsPattern" <|
+        \context ->
+            """
 module Page exposing (view)
 view ((Page.Document title _) as doc) = Html.text title
 """
-                    |> Review.Test.run (valueVisitorRule context)
-                    |> Review.Test.expectErrors
-                        [ expectedValueError context "Page.Document"
-                        , expectedValueError context "Html.text"
-                        , expectedValueError context "title"
-                            |> Review.Test.atExactly { start = { row = 3, column = 51 }, end = { row = 3, column = 56 } }
-                        ]
-        , fuzz Fuzz.string "ParenthesizedPattern" <|
-            \context ->
-                """
+                |> Review.Test.run (valueVisitorRule context)
+                |> Review.Test.expectErrors
+                    [ expectedValueError context "Page.Document"
+                    , expectedValueError context "Html.text"
+                    , expectedValueError context "title"
+                        |> Review.Test.atExactly { start = { row = 3, column = 51 }, end = { row = 3, column = 56 } }
+                    ]
+    , fuzz Fuzz.string "ParenthesizedPattern" <|
+        \context ->
+            """
 module Page exposing (view)
 view (Nested.Node name) = Html.text name
 """
-                    |> Review.Test.run (valueVisitorRule context)
-                    |> Review.Test.expectErrors
-                        [ expectedValueError context "Nested.Node"
-                        , expectedValueError context "Html.text"
-                        , expectedValueError context "name"
-                            |> Review.Test.atExactly { start = { row = 3, column = 37 }, end = { row = 3, column = 41 } }
-                        ]
-        ]
+                |> Review.Test.run (valueVisitorRule context)
+                |> Review.Test.expectErrors
+                    [ expectedValueError context "Nested.Node"
+                    , expectedValueError context "Html.text"
+                    , expectedValueError context "name"
+                        |> Review.Test.atExactly { start = { row = 3, column = 37 }, end = { row = 3, column = 41 } }
+                    ]
+    ]
 
 
-typeAnnotationTests : Test
+typeAnnotationTests : List Test
 typeAnnotationTests =
-    describe "TypeAnnotation"
-        [ fuzz Fuzz.string "Types" <|
-            \context ->
-                """
+    [ fuzz Fuzz.string "Types" <|
+        \context ->
+            """
 module Page exposing (view)
 view : Nested.Node Page.Document msg -> Html msg
 view node = div [] []
 """
-                    |> Review.Test.run (typeVisitorRule context)
-                    |> Review.Test.expectErrors
-                        [ expectedTypeError context "Nested.Node"
-                        , expectedTypeError context "Page.Document"
-                        , expectedTypeError context "Html"
-                        ]
-        , fuzz Fuzz.string "Tupled" <|
-            \context ->
-                """
+                |> Review.Test.run (typeVisitorRule context)
+                |> Review.Test.expectErrors
+                    [ expectedTypeError context "Nested.Node"
+                    , expectedTypeError context "Page.Document"
+                    , expectedTypeError context "Html"
+                    ]
+    , fuzz Fuzz.string "Tupled" <|
+        \context ->
+            """
 module Page exposing (Page)
 type Page
     = Page ( Document.Title, Document.List Document.Item )
 """
-                    |> Review.Test.run (typeVisitorRule context)
-                    |> Review.Test.expectErrors
-                        [ expectedTypeError context "Document.Title"
-                        , expectedTypeError context "Document.List"
-                        , expectedTypeError context "Document.Item"
-                        ]
-        , fuzz Fuzz.string "Record" <|
-            \context ->
-                """
+                |> Review.Test.run (typeVisitorRule context)
+                |> Review.Test.expectErrors
+                    [ expectedTypeError context "Document.Title"
+                    , expectedTypeError context "Document.List"
+                    , expectedTypeError context "Document.Item"
+                    ]
+    , fuzz Fuzz.string "Record" <|
+        \context ->
+            """
 module Page exposing (Page)
 type Page
     = Page { title : Document.Title, body : Document.List Document.Item }
 """
-                    |> Review.Test.run (typeVisitorRule context)
-                    |> Review.Test.expectErrors
-                        [ expectedTypeError context "Document.Title"
-                        , expectedTypeError context "Document.List"
-                        , expectedTypeError context "Document.Item"
-                        ]
-        , fuzz Fuzz.string "GenericRecord" <|
-            \context ->
-                """
+                |> Review.Test.run (typeVisitorRule context)
+                |> Review.Test.expectErrors
+                    [ expectedTypeError context "Document.Title"
+                    , expectedTypeError context "Document.List"
+                    , expectedTypeError context "Document.Item"
+                    ]
+    , fuzz Fuzz.string "GenericRecord" <|
+        \context ->
+            """
 module Page exposing (Page)
 type Page
     = Page { page | title : Document.Title, body : Document.List Document.Item }
 """
-                    |> Review.Test.run (typeVisitorRule context)
-                    |> Review.Test.expectErrors
-                        [ expectedTypeError context "Document.Title"
-                        , expectedTypeError context "Document.List"
-                        , expectedTypeError context "Document.Item"
-                        ]
-        , fuzz Fuzz.string "FunctionTypeAnnotation" <|
-            \context ->
-                """
+                |> Review.Test.run (typeVisitorRule context)
+                |> Review.Test.expectErrors
+                    [ expectedTypeError context "Document.Title"
+                    , expectedTypeError context "Document.List"
+                    , expectedTypeError context "Document.Item"
+                    ]
+    , fuzz Fuzz.string "FunctionTypeAnnotation" <|
+        \context ->
+            """
 module Page exposing (Viewer)
 type Viewer msg
     = Viewer (Document.Title -> Document.List Document.Item -> Html msg)
 """
-                    |> Review.Test.run (typeVisitorRule context)
-                    |> Review.Test.expectErrors
-                        [ expectedTypeError context "Document.Title"
-                        , expectedTypeError context "Document.List"
-                        , expectedTypeError context "Document.Item"
-                        , expectedTypeError context "Html"
-                        ]
-        ]
+                |> Review.Test.run (typeVisitorRule context)
+                |> Review.Test.expectErrors
+                    [ expectedTypeError context "Document.Title"
+                    , expectedTypeError context "Document.List"
+                    , expectedTypeError context "Document.Item"
+                    , expectedTypeError context "Html"
+                    ]
+    ]
 
 
-visitorTests : Test
+visitorTests : List Test
 visitorTests =
-    describe "Visitors"
-        [ fuzz Fuzz.string "withNameVisitor" <|
-            \context ->
-                """
+    [ fuzz Fuzz.string "withNameVisitor" <|
+        \context ->
+            """
 module Page exposing (view)
 view : Page -> Html msg
 view page =
     Html.div [] (Page.body page)
 """
-                    |> Review.Test.run (nameVisitorRule context)
-                    |> Review.Test.expectErrors
-                        [ expectedNameError context "Page"
-                            |> Review.Test.atExactly { start = { row = 3, column = 8 }, end = { row = 3, column = 12 } }
-                        , expectedNameError context "Html"
-                            |> Review.Test.atExactly { start = { row = 3, column = 16 }, end = { row = 3, column = 20 } }
-                        , expectedNameError context "Html.div"
-                        , expectedNameError context "Page.body"
-                        , expectedNameError context "page"
-                            |> Review.Test.atExactly { start = { row = 5, column = 28 }, end = { row = 5, column = 32 } }
-                        ]
-        , fuzz Fuzz.string "withValueVisitor" <|
-            \context ->
-                """
+                |> Review.Test.run (nameVisitorRule context)
+                |> Review.Test.expectErrors
+                    [ expectedNameError context "Page"
+                        |> Review.Test.atExactly { start = { row = 3, column = 8 }, end = { row = 3, column = 12 } }
+                    , expectedNameError context "Html"
+                        |> Review.Test.atExactly { start = { row = 3, column = 16 }, end = { row = 3, column = 20 } }
+                    , expectedNameError context "Html.div"
+                    , expectedNameError context "Page.body"
+                    , expectedNameError context "page"
+                        |> Review.Test.atExactly { start = { row = 5, column = 28 }, end = { row = 5, column = 32 } }
+                    ]
+    , fuzz Fuzz.string "withValueVisitor" <|
+        \context ->
+            """
 module Page exposing (view)
 view : Page -> Html msg
 view page =
     Html.div [] (Page.body page)
 """
-                    |> Review.Test.run (valueVisitorRule context)
-                    |> Review.Test.expectErrors
-                        [ expectedValueError context "Html.div"
-                        , expectedValueError context "Page.body"
-                        , expectedValueError context "page"
-                            |> Review.Test.atExactly { start = { row = 5, column = 28 }, end = { row = 5, column = 32 } }
-                        ]
-        , fuzz Fuzz.string "withTypeVisitor" <|
-            \context ->
-                """
+                |> Review.Test.run (valueVisitorRule context)
+                |> Review.Test.expectErrors
+                    [ expectedValueError context "Html.div"
+                    , expectedValueError context "Page.body"
+                    , expectedValueError context "page"
+                        |> Review.Test.atExactly { start = { row = 5, column = 28 }, end = { row = 5, column = 32 } }
+                    ]
+    , fuzz Fuzz.string "withTypeVisitor" <|
+        \context ->
+            """
 module Page exposing (view)
 view : Page -> Html msg
 view page =
     Html.div [] (Page.body page)
 """
-                    |> Review.Test.run (typeVisitorRule context)
-                    |> Review.Test.expectErrors
-                        [ expectedTypeError context "Page"
-                            |> Review.Test.atExactly { start = { row = 3, column = 8 }, end = { row = 3, column = 12 } }
-                        , expectedTypeError context "Html"
-                            |> Review.Test.atExactly { start = { row = 3, column = 16 }, end = { row = 3, column = 20 } }
-                        ]
-        , fuzz Fuzz.string "withValueOrTypeVisitor" <|
-            \context ->
-                """
+                |> Review.Test.run (typeVisitorRule context)
+                |> Review.Test.expectErrors
+                    [ expectedTypeError context "Page"
+                        |> Review.Test.atExactly { start = { row = 3, column = 8 }, end = { row = 3, column = 12 } }
+                    , expectedTypeError context "Html"
+                        |> Review.Test.atExactly { start = { row = 3, column = 16 }, end = { row = 3, column = 20 } }
+                    ]
+    , fuzz Fuzz.string "withValueOrTypeVisitor" <|
+        \context ->
+            """
 module Page exposing (view)
 view : Page -> Html msg
 view page =
     Html.div [] (Page.body page)
 """
-                    |> Review.Test.run (valueOrTypeVisitorRule context)
-                    |> Review.Test.expectErrors
-                        [ expectedTypeError context "Page"
-                            |> Review.Test.atExactly { start = { row = 3, column = 8 }, end = { row = 3, column = 12 } }
-                        , expectedTypeError context "Html"
-                            |> Review.Test.atExactly { start = { row = 3, column = 16 }, end = { row = 3, column = 20 } }
-                        , expectedValueError context "Html.div"
-                        , expectedValueError context "Page.body"
-                        , expectedValueError context "page"
-                            |> Review.Test.atExactly { start = { row = 5, column = 28 }, end = { row = 5, column = 32 } }
-                        ]
-        ]
+                |> Review.Test.run (valueOrTypeVisitorRule context)
+                |> Review.Test.expectErrors
+                    [ expectedTypeError context "Page"
+                        |> Review.Test.atExactly { start = { row = 3, column = 8 }, end = { row = 3, column = 12 } }
+                    , expectedTypeError context "Html"
+                        |> Review.Test.atExactly { start = { row = 3, column = 16 }, end = { row = 3, column = 20 } }
+                    , expectedValueError context "Html.div"
+                    , expectedValueError context "Page.body"
+                    , expectedValueError context "page"
+                        |> Review.Test.atExactly { start = { row = 5, column = 28 }, end = { row = 5, column = 32 } }
+                    ]
+    ]
 
 
-contextTests : Test
+contextTests : List Test
 contextTests =
-    describe "Context"
-        [ test "mutates context" <|
-            \_ ->
-                """
+    [ test "mutates context" <|
+        \_ ->
+            """
 module Page exposing (Page)
 view : Page -> Html msg
 view page =
     Html.div [] (Page.body page)
 """
-                    |> Review.Test.run (countingVisitorRule 0)
-                    |> Review.Test.expectErrors
-                        [ expectedNameError "0" "Page"
-                            |> Review.Test.atExactly { start = { row = 3, column = 8 }, end = { row = 3, column = 12 } }
-                        , expectedNameError "1" "Html"
-                            |> Review.Test.atExactly { start = { row = 3, column = 16 }, end = { row = 3, column = 20 } }
-                        , expectedNameError "2" "Html.div"
-                        , expectedNameError "3" "Page.body"
-                        , expectedNameError "4" "page"
-                            |> Review.Test.atExactly { start = { row = 5, column = 28 }, end = { row = 5, column = 32 } }
-                        ]
-        ]
+                |> Review.Test.run (countingVisitorRule 0)
+                |> Review.Test.expectErrors
+                    [ expectedNameError "0" "Page"
+                        |> Review.Test.atExactly { start = { row = 3, column = 8 }, end = { row = 3, column = 12 } }
+                    , expectedNameError "1" "Html"
+                        |> Review.Test.atExactly { start = { row = 3, column = 16 }, end = { row = 3, column = 20 } }
+                    , expectedNameError "2" "Html.div"
+                    , expectedNameError "3" "Page.body"
+                    , expectedNameError "4" "page"
+                        |> Review.Test.atExactly { start = { row = 5, column = 28 }, end = { row = 5, column = 32 } }
+                    ]
+    ]
 
 
 

--- a/tests/Tests/NameVisitor.elm
+++ b/tests/Tests/NameVisitor.elm
@@ -162,6 +162,19 @@ view nodes =
                     , expectedValueError context "name"
                         |> Review.Test.atExactly { start = { row = 4, column = 54 }, end = { row = 4, column = 58 } }
                     ]
+    , fuzz Fuzz.string "RecordUpdateExpression" <|
+        \context ->
+            """
+module Page exposing (view)
+update model =
+    { model | key = value }
+"""
+                |> Review.Test.run (valueOrTypeVisitorRule context)
+                |> Review.Test.expectErrors
+                    [ expectedValueError context "model"
+                        |> Review.Test.atExactly { start = { row = 4, column = 7 }, end = { row = 4, column = 12 } }
+                    , expectedValueError context "value"
+                    ]
     ]
 
 


### PR DESCRIPTION
This will visit the value used at the head of a record update expression...

```elm
-- visit "record"
{ record | key = value }
```