### PR TITLE
Use withExpressionEnterVisitor instead of deprecated withExpressionVisitor

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -10,8 +10,8 @@
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
         "elm/core": "1.0.5 <= v < 2.0.0",
-        "jfmengels/elm-review": "2.0.0 <= v < 3.0.0",
-        "stil4m/elm-syntax": "7.1.1 <= v < 8.0.0"
+        "jfmengels/elm-review": "2.2.0 <= v < 3.0.0",
+        "stil4m/elm-syntax": "7.1.3 <= v < 8.0.0"
     },
     "test-dependencies": {
         "elm-explorations/test": "1.2.2 <= v < 2.0.0"

--- a/src/NameVisitor.elm
+++ b/src/NameVisitor.elm
@@ -79,7 +79,7 @@ withNameVisitor nameVisitor rule =
     in
     rule
         |> Rule.withDeclarationListVisitor (declarationListVisitor visitor)
-        |> Rule.withExpressionVisitor (expressionVisitor visitor)
+        |> Rule.withExpressionEnterVisitor (expressionVisitor visitor)
 
 
 {-| This will apply the `valueVisitor` to every value in the module, and ignore any types.
@@ -107,7 +107,7 @@ withValueVisitor valueVisitor rule =
     in
     rule
         |> Rule.withDeclarationListVisitor (declarationListVisitor visitor)
-        |> Rule.withExpressionVisitor (expressionVisitor visitor)
+        |> Rule.withExpressionEnterVisitor (expressionVisitor visitor)
 
 
 {-| This will apply the `typeVisitor` to every type in the module, and ignore any values.
@@ -135,7 +135,7 @@ withTypeVisitor typeVisitor rule =
     in
     rule
         |> Rule.withDeclarationListVisitor (declarationListVisitor visitor)
-        |> Rule.withExpressionVisitor (expressionVisitor visitor)
+        |> Rule.withExpressionEnterVisitor (expressionVisitor visitor)
 
 
 {-| This will apply the `valueVisitor` to every value and the `typeVisitor` to every type in the module.
@@ -173,7 +173,7 @@ withValueAndTypeVisitors { valueVisitor, typeVisitor } rule =
     in
     rule
         |> Rule.withDeclarationListVisitor (declarationListVisitor visitor)
-        |> Rule.withExpressionVisitor (expressionVisitor visitor)
+        |> Rule.withExpressionEnterVisitor (expressionVisitor visitor)
 
 
 
@@ -188,17 +188,10 @@ declarationListVisitor visitor list context =
         |> folder visitor context
 
 
-expressionVisitor :
-    Visitor context
-    -> (Node Expression -> Rule.Direction -> context -> ( List (Error {}), context ))
-expressionVisitor visitor node direction context =
-    case direction of
-        Rule.OnEnter ->
-            visitExpression node
-                |> folder visitor context
-
-        Rule.OnExit ->
-            ( [], context )
+expressionVisitor : Visitor context -> (Node Expression -> context -> ( List (Error {}), context ))
+expressionVisitor visitor node context =
+    visitExpression node
+        |> folder visitor context
 
 
 


### PR DESCRIPTION
Use withExpressionEnterVisitor instead of deprecated withExpressionVisitor.
This should speed things up by not having to handle and visit the expression on exit.

This does require `jfmengels/elm-review` v2.2.0.
This still needs a version bump (0.3.0?) and a tag.